### PR TITLE
Bump dependencies and code cleanup

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,8 +5,7 @@
 ### All Submissions:
 
 - [ ] Have you selected the correct base branch per [Contributing](https://github.com/metaschema-framework/oscal-cli/blob/main/CONTRIBUTING.md) guidance?
-- [ ] Have you set "[Allow edits and access to secrets by maintainers
-](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
+- [ ] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
 - [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/oscal-cli/pulls) for the same update/change?
 - [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
 - [ ] Do all automated CI/CD checks pass?

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
 	<properties>
 		<!-- metaschema dependencies -->
 		<dependency.metaschema-framework.version>1.1.0</dependency.metaschema-framework.version>
-		<dependency.liboscal-java.version>4.1.0-SNAPSHOT</dependency.liboscal-java.version>
+		<dependency.liboscal-java.version>4.1.0</dependency.liboscal-java.version>
 
 		<!-- site configuration -->
 		<site.url>https://oscal-cli.metaschema.dev</site.url>

--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
 	
 	<properties>
 		<!-- metaschema dependencies -->
-		<dependency.metaschema-framework.version>1.0.2</dependency.metaschema-framework.version>
-		<dependency.liboscal-java.version>4.0.2</dependency.liboscal-java.version>
+		<dependency.metaschema-framework.version>1.1.0</dependency.metaschema-framework.version>
+		<dependency.liboscal-java.version>4.1.0-SNAPSHOT</dependency.liboscal-java.version>
 
 		<!-- site configuration -->
 		<site.url>https://oscal-cli.metaschema.dev</site.url>
@@ -89,7 +89,7 @@
 		<dependency.json.version>20240303</dependency.json.version>
 		<dependency.log4j2.version>2.23.1</dependency.log4j2.version>
 		<dependency.pmd.version>7.4.0</dependency.pmd.version>
-		<dependency.spotbugs-annotations.version>4.8.3</dependency.spotbugs-annotations.version>
+		<dependency.spotbugs-annotations.version>4.8.6</dependency.spotbugs-annotations.version>
 		<dependency.saxon-he.version>12.5</dependency.saxon-he.version>
 		<dependency.xmlbeans.version>5.2.1</dependency.xmlbeans.version>
 		<dependency.xmlresolver.version>6.0.9</dependency.xmlresolver.version>
@@ -297,8 +297,7 @@
 				<configuration>
 					<dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
 					<generateGitPropertiesFile>true</generateGitPropertiesFile>
-					<generateGitPropertiesFilename>
-						${project.build.directory}/git.properties</generateGitPropertiesFilename>
+					<generateGitPropertiesFilename>${project.build.directory}/git.properties</generateGitPropertiesFilename>
 					<verbose>true</verbose>
 					<useNativeGit>false</useNativeGit>
 					<prefix>git</prefix>
@@ -323,8 +322,7 @@
 							<addClasspath>true</addClasspath>
 							<!-- <classpathPrefix>lib/</classpathPrefix> -->
 							<classpathLayoutType>custom</classpathLayoutType>
-							<customClasspathLayout>
-								${artifact.groupId}.${artifact.artifactId}-$${artifact.version}.${artifact.extension}</customClasspathLayout>
+							<customClasspathLayout>${artifact.groupId}.${artifact.artifactId}-$${artifact.version}.${artifact.extension}</customClasspathLayout>
 						</manifest>
 					</archive>
 				</configuration>
@@ -343,10 +341,8 @@
 					<generateRepository>false</generateRepository>
 					<repositoryLayout>flat</repositoryLayout>
 					<repositoryName>lib</repositoryName>
-					<outputFileNameMapping>
-						@{groupId}@.@{artifactId}@-@{version}@.@{extension}@</outputFileNameMapping>
-					<extraJvmArguments>-Dsun.stdout.encoding=UTF-8
-						-Dsun.stderr.encoding=UTF-8</extraJvmArguments>
+					<outputFileNameMapping>@{groupId}@.@{artifactId}@-@{version}@@{dashClassifier?}@.@{extension}@</outputFileNameMapping>
+					<extraJvmArguments>-Dsun.stdout.encoding=UTF-8 -Dsun.stderr.encoding=UTF-8</extraJvmArguments>
 					<projectArtifactFirstInClassPath>true</projectArtifactFirstInClassPath>
 					<includeConfigurationDirectoryInClasspath>false</includeConfigurationDirectoryInClasspath>
 				</configuration>
@@ -424,8 +420,7 @@
 							<goal>add-third-party</goal>
 						</goals>
 						<configuration>
-							<outputDirectory>
-								${project.build.directory}/generated-distro</outputDirectory>
+							<outputDirectory>${project.build.directory}/generated-distro</outputDirectory>
 							<thirdPartyFilename>LICENSE-THIRD-PARTY.txt</thirdPartyFilename>
 							<licenseMerges>
 								<licenseMerge>The Apache Software License,
@@ -453,7 +448,7 @@
 				<artifactId>maven-jxr-plugin</artifactId>
 				<reportSets>
 					<reportSet>
-            <id>default</id>
+                        <id>default</id>
 						<configuration>
 							<linkJavadoc>false</linkJavadoc>
 						</configuration>

--- a/src/main/assembly/bin.xml
+++ b/src/main/assembly/bin.xml
@@ -12,7 +12,7 @@
 	<dependencySets>
 		<dependencySet>
 			<outputDirectory>/lib</outputDirectory>
-			<outputFileNameMapping>${artifact.groupId}.${artifact.artifactId}-${artifact.version}.${artifact.extension}</outputFileNameMapping>
+			<outputFileNameMapping>${artifact.groupId}.${artifact.artifactId}-${artifact.version}${dashClassifier?}.${artifact.extension}</outputFileNameMapping>
 			<useProjectArtifact>true</useProjectArtifact>
 			<excludes>
 				<exclude>org.jetbrains:annotations</exclude>

--- a/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/AbstractOscalConvertCommand.java
+++ b/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/AbstractOscalConvertCommand.java
@@ -26,9 +26,9 @@ import java.net.URI;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-public abstract class AbstractOscalConvertSubcommand
+public abstract class AbstractOscalConvertCommand
     extends AbstractConvertSubcommand {
-  private static final Logger LOGGER = LogManager.getLogger(AbstractOscalConvertSubcommand.class);
+  private static final Logger LOGGER = LogManager.getLogger(AbstractOscalConvertCommand.class);
 
   @NonNull
   public abstract Class<? extends IBoundObject> getOscalClass();

--- a/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/AbstractOscalValidationCommand.java
+++ b/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/AbstractOscalValidationCommand.java
@@ -26,7 +26,7 @@ import javax.xml.transform.Source;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-public abstract class AbstractOscalValidationSubcommand
+public abstract class AbstractOscalValidationCommand
     extends AbstractValidateContentCommand {
 
   @NonNull

--- a/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/AbstractRenderCommand.java
+++ b/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/AbstractRenderCommand.java
@@ -34,9 +34,9 @@ import javax.xml.transform.TransformerException;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-public abstract class AbstractRenderSubcommand
+public abstract class AbstractRenderCommand
     extends AbstractTerminalCommand {
-  private static final Logger LOGGER = LogManager.getLogger(AbstractRenderSubcommand.class);
+  private static final Logger LOGGER = LogManager.getLogger(AbstractRenderCommand.class);
 
   @NonNull
   private static final String COMMAND = "render";

--- a/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/ValidateCommand.java
+++ b/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/ValidateCommand.java
@@ -23,7 +23,7 @@ import javax.xml.transform.Source;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public class ValidateCommand
-    extends AbstractOscalValidationSubcommand {
+    extends AbstractOscalValidationCommand {
   @Override
   public String getDescription() {
     return "Check that the specified OSCAL instance is well-formed and valid to an OSCAL model.";

--- a/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/assessmentplan/ConvertSubcommand.java
+++ b/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/assessmentplan/ConvertSubcommand.java
@@ -7,10 +7,10 @@ package gov.nist.secauto.oscal.tools.cli.core.commands.assessmentplan;
 
 import gov.nist.secauto.metaschema.core.model.IBoundObject;
 import gov.nist.secauto.oscal.lib.model.AssessmentPlan;
-import gov.nist.secauto.oscal.tools.cli.core.commands.AbstractOscalConvertSubcommand;
+import gov.nist.secauto.oscal.tools.cli.core.commands.AbstractOscalConvertCommand;
 
 public class ConvertSubcommand
-    extends AbstractOscalConvertSubcommand {
+    extends AbstractOscalConvertCommand {
   @Override
   public String getDescription() {
     return "Convert the specified OSCAL Assessment Plan to a different format";

--- a/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/assessmentresults/ConvertSubcommand.java
+++ b/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/assessmentresults/ConvertSubcommand.java
@@ -7,10 +7,10 @@ package gov.nist.secauto.oscal.tools.cli.core.commands.assessmentresults;
 
 import gov.nist.secauto.metaschema.core.model.IBoundObject;
 import gov.nist.secauto.oscal.lib.model.AssessmentResults;
-import gov.nist.secauto.oscal.tools.cli.core.commands.AbstractOscalConvertSubcommand;
+import gov.nist.secauto.oscal.tools.cli.core.commands.AbstractOscalConvertCommand;
 
 public class ConvertSubcommand
-    extends AbstractOscalConvertSubcommand {
+    extends AbstractOscalConvertCommand {
   @Override
   public String getDescription() {
     return "Convert the specified OSCAL Assessment Results to a different format";

--- a/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/catalog/ConvertSubcommand.java
+++ b/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/catalog/ConvertSubcommand.java
@@ -7,10 +7,10 @@ package gov.nist.secauto.oscal.tools.cli.core.commands.catalog;
 
 import gov.nist.secauto.metaschema.core.model.IBoundObject;
 import gov.nist.secauto.oscal.lib.model.Catalog;
-import gov.nist.secauto.oscal.tools.cli.core.commands.AbstractOscalConvertSubcommand;
+import gov.nist.secauto.oscal.tools.cli.core.commands.AbstractOscalConvertCommand;
 
 public class ConvertSubcommand
-    extends AbstractOscalConvertSubcommand {
+    extends AbstractOscalConvertCommand {
 
   @Override
   public String getDescription() {

--- a/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/catalog/RenderSubcommand.java
+++ b/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/catalog/RenderSubcommand.java
@@ -5,7 +5,7 @@
 
 package gov.nist.secauto.oscal.tools.cli.core.commands.catalog;
 
-import gov.nist.secauto.oscal.tools.cli.core.commands.AbstractRenderSubcommand;
+import gov.nist.secauto.oscal.tools.cli.core.commands.AbstractRenderCommand;
 import gov.nist.secauto.oscal.tools.cli.core.operations.XMLOperations;
 
 import java.io.IOException;
@@ -14,7 +14,7 @@ import java.nio.file.Path;
 import javax.xml.transform.TransformerException;
 
 public class RenderSubcommand
-    extends AbstractRenderSubcommand {
+    extends AbstractRenderCommand {
   @Override
   public String getDescription() {
     return "Render the specified OSCAL Catalog as HTML";

--- a/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/componentdefinition/ConvertSubcommand.java
+++ b/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/componentdefinition/ConvertSubcommand.java
@@ -7,10 +7,10 @@ package gov.nist.secauto.oscal.tools.cli.core.commands.componentdefinition;
 
 import gov.nist.secauto.metaschema.core.model.IBoundObject;
 import gov.nist.secauto.oscal.lib.model.ComponentDefinition;
-import gov.nist.secauto.oscal.tools.cli.core.commands.AbstractOscalConvertSubcommand;
+import gov.nist.secauto.oscal.tools.cli.core.commands.AbstractOscalConvertCommand;
 
 public class ConvertSubcommand
-    extends AbstractOscalConvertSubcommand {
+    extends AbstractOscalConvertCommand {
   @Override
   public String getDescription() {
     return "Convert the specified OSCAL Component Definition to a different format";

--- a/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/oscal/AbstractDeprecatedOscalValidationSubcommand.java
+++ b/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/oscal/AbstractDeprecatedOscalValidationSubcommand.java
@@ -8,7 +8,7 @@ package gov.nist.secauto.oscal.tools.cli.core.commands.oscal;
 import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
 import gov.nist.secauto.metaschema.cli.processor.ExitStatus;
 import gov.nist.secauto.metaschema.cli.processor.command.ICommandExecutor;
-import gov.nist.secauto.oscal.tools.cli.core.commands.AbstractOscalValidationSubcommand;
+import gov.nist.secauto.oscal.tools.cli.core.commands.AbstractOscalValidationCommand;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.logging.log4j.LogManager;
@@ -17,7 +17,7 @@ import org.apache.logging.log4j.Logger;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public abstract class AbstractDeprecatedOscalValidationSubcommand
-    extends AbstractOscalValidationSubcommand {
+    extends AbstractOscalValidationCommand {
   private static final Logger LOGGER = LogManager.getLogger(AbstractDeprecatedOscalValidationSubcommand.class);
 
   @Override
@@ -26,7 +26,7 @@ public abstract class AbstractDeprecatedOscalValidationSubcommand
   }
 
   protected final class DeprecatedOscalCommandExecutor
-      extends AbstractOscalValidationSubcommand.OscalCommandExecutor {
+      extends AbstractOscalValidationCommand.OscalCommandExecutor {
 
     private DeprecatedOscalCommandExecutor(
         @NonNull CallingContext callingContext,

--- a/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/poam/ConvertSubcommand.java
+++ b/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/poam/ConvertSubcommand.java
@@ -7,10 +7,10 @@ package gov.nist.secauto.oscal.tools.cli.core.commands.poam;
 
 import gov.nist.secauto.metaschema.core.model.IBoundObject;
 import gov.nist.secauto.oscal.lib.model.PlanOfActionAndMilestones;
-import gov.nist.secauto.oscal.tools.cli.core.commands.AbstractOscalConvertSubcommand;
+import gov.nist.secauto.oscal.tools.cli.core.commands.AbstractOscalConvertCommand;
 
 public class ConvertSubcommand
-    extends AbstractOscalConvertSubcommand {
+    extends AbstractOscalConvertCommand {
   @Override
   public String getDescription() {
     return "Convert the specified OSCAL Plan of Actions and Milestones to a different format";

--- a/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/profile/ConvertSubcommand.java
+++ b/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/profile/ConvertSubcommand.java
@@ -7,10 +7,10 @@ package gov.nist.secauto.oscal.tools.cli.core.commands.profile;
 
 import gov.nist.secauto.metaschema.core.model.IBoundObject;
 import gov.nist.secauto.oscal.lib.model.Profile;
-import gov.nist.secauto.oscal.tools.cli.core.commands.AbstractOscalConvertSubcommand;
+import gov.nist.secauto.oscal.tools.cli.core.commands.AbstractOscalConvertCommand;
 
 public class ConvertSubcommand
-    extends AbstractOscalConvertSubcommand {
+    extends AbstractOscalConvertCommand {
   @Override
   public String getDescription() {
     return "Convert a specified OSCAL Profile to a different format";

--- a/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/profile/RenderSubcommand.java
+++ b/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/profile/RenderSubcommand.java
@@ -5,7 +5,7 @@
 
 package gov.nist.secauto.oscal.tools.cli.core.commands.profile;
 
-import gov.nist.secauto.oscal.tools.cli.core.commands.AbstractRenderSubcommand;
+import gov.nist.secauto.oscal.tools.cli.core.commands.AbstractRenderCommand;
 import gov.nist.secauto.oscal.tools.cli.core.operations.XMLOperations;
 
 import java.io.IOException;
@@ -14,7 +14,7 @@ import java.nio.file.Path;
 import javax.xml.transform.TransformerException;
 
 public class RenderSubcommand
-    extends AbstractRenderSubcommand {
+    extends AbstractRenderCommand {
   @Override
   public String getDescription() {
     return "Render the specified OSCAL Profile as HTML";

--- a/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/ssp/ConvertSubcommand.java
+++ b/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/ssp/ConvertSubcommand.java
@@ -7,10 +7,10 @@ package gov.nist.secauto.oscal.tools.cli.core.commands.ssp;
 
 import gov.nist.secauto.metaschema.core.model.IBoundObject;
 import gov.nist.secauto.oscal.lib.model.SystemSecurityPlan;
-import gov.nist.secauto.oscal.tools.cli.core.commands.AbstractOscalConvertSubcommand;
+import gov.nist.secauto.oscal.tools.cli.core.commands.AbstractOscalConvertCommand;
 
 public class ConvertSubcommand
-    extends AbstractOscalConvertSubcommand {
+    extends AbstractOscalConvertCommand {
   @Override
   public String getDescription() {
     return "Convert the specified OSCAL System Security Plan to a different format";

--- a/src/test/java/gov/nist/secauto/oscal/tools/cli/core/commands/Issue96ClassLoaderTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/tools/cli/core/commands/Issue96ClassLoaderTest.java
@@ -16,42 +16,42 @@ class Issue96ClassLoaderTest {
    */
   @Test
   void testAssessmentPlanClassLoader() {
-    AbstractOscalConvertSubcommand subcommand
+    AbstractOscalConvertCommand subcommand
         = new gov.nist.secauto.oscal.tools.cli.core.commands.assessmentplan.ConvertSubcommand();
     assertEquals("AssessmentPlan", subcommand.getOscalClass().getSimpleName());
   }
 
   @Test
   void testAssessmentResultsClassLoader() {
-    AbstractOscalConvertSubcommand subcommand
+    AbstractOscalConvertCommand subcommand
         = new gov.nist.secauto.oscal.tools.cli.core.commands.assessmentresults.ConvertSubcommand();
     assertEquals("AssessmentResults", subcommand.getOscalClass().getSimpleName());
   }
 
   @Test
   void testCatalogClassLoader() {
-    AbstractOscalConvertSubcommand subcommand
+    AbstractOscalConvertCommand subcommand
         = new gov.nist.secauto.oscal.tools.cli.core.commands.catalog.ConvertSubcommand();
     assertEquals("Catalog", subcommand.getOscalClass().getSimpleName());
   }
 
   @Test
   void testPoamClassLoader() {
-    AbstractOscalConvertSubcommand subcommand
+    AbstractOscalConvertCommand subcommand
         = new gov.nist.secauto.oscal.tools.cli.core.commands.poam.ConvertSubcommand();
     assertEquals("PlanOfActionAndMilestones", subcommand.getOscalClass().getSimpleName());
   }
 
   @Test
   void testSspClassLoader() {
-    AbstractOscalConvertSubcommand subcommand
+    AbstractOscalConvertCommand subcommand
         = new gov.nist.secauto.oscal.tools.cli.core.commands.ssp.ConvertSubcommand();
     assertEquals("SystemSecurityPlan", subcommand.getOscalClass().getSimpleName());
   }
 
   @Test
   void testComponentDefinitionClassLoader() {
-    AbstractOscalConvertSubcommand subcommand
+    AbstractOscalConvertCommand subcommand
         = new gov.nist.secauto.oscal.tools.cli.core.commands.componentdefinition.ConvertSubcommand();
     assertEquals("ComponentDefinition", subcommand.getOscalClass().getSimpleName());
   }


### PR DESCRIPTION
# Committer Notes

This is a maintenance PR that addresses a few small things.
- Bumped metaschema-java from 1.0.2 to 1.1.0.
- Bumped liboscal-java from 4.0.2 to 4.1.0.
- Bumped spotbugs-annotations from 4.8.3 to 4.8.6.
- Improved class naming consistency for commands.
- Fixed a dependency management issue with CLI dependencies that will cause class not found exceptions.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/metaschema-framework/oscal-cli/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you set "[Allow edits and access to secrets by maintainers
](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/oscal-cli/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?
