### PR TITLE
oscal-cli resolve --relative-to=URI

### DIFF
--- a/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/ListAllowedValuesCommand.java
+++ b/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/ListAllowedValuesCommand.java
@@ -89,7 +89,7 @@ public class ListAllowedValuesCommand
 
   @Override
   public String getDescription() {
-    return "Generate a diagram for the provided Metaschema module";
+    return "List allowed values constraints for the provided Metaschema module";
   }
 
   @SuppressWarnings("null")


### PR DESCRIPTION
# Committer Notes

Added the `--relative-to=URI` argument to the `resolve` command to support relative generated links during profile resolution.

Resolves #84.
Depends on https://github.com/metaschema-framework/liboscal-java/pull/94.

### All Submissions:

- [x] Have you selected the correct base branch per [Contributing](https://github.com/metaschema-framework/oscal-cli/blob/main/CONTRIBUTING.md) guidance?
- [x] Have you followed the guidelines in our [Contributing](https://github.com/metaschema-framework/oscal-cli/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/metaschema-framework/oscal-cli/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Have you set "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)"?

By submitting a pull request, you are agreeing to provide this contribution under the [CC0 1.0 Universal public domain](https://creativecommons.org/publicdomain/zero/1.0/) dedication.

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website and readme documentation affected by the changes you made?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new command-line option for generating relative URI references.
	- Users can now specify a base URI for reference generation via the new `RELATIVE_TO` option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->