### PR TITLE
Add --pretty-print option for profile resolution output

### DIFF
--- a/src/main/java/gov/nist/secauto/oscal/tools/cli/core/utils/PrettyPrinter.java
+++ b/src/main/java/gov/nist/secauto/oscal/tools/cli/core/utils/PrettyPrinter.java
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.oscal.tools.cli.core.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import net.sf.saxon.TransformerFactoryImpl;
+
+import org.w3c.dom.Document;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.xml.sax.SAXException;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Utility class for pretty-printing output files in various formats.
+ * <p>
+ * This class was originally contributed by Mahesh Kumar Gaddam (ermahesh) in
+ * <a href="https://github.com/usnistgov/oscal-cli/pull/295">PR #295</a>.
+ * </p>
+ */
+public final class PrettyPrinter {
+
+  private PrettyPrinter() {
+    // prevent instantiation
+  }
+
+  /**
+   * Pretty-prints a JSON file in place.
+   *
+   * @param file
+   *          the JSON file to pretty-print
+   * @throws IOException
+   *           if an I/O error occurs
+   */
+  public static void prettyPrintJson(@NonNull File file) throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    Object obj = mapper.readValue(file, Object.class);
+    mapper.writerWithDefaultPrettyPrinter().writeValue(file, obj);
+  }
+
+  /**
+   * Pretty-prints a YAML file in place.
+   *
+   * @param file
+   *          the YAML file to pretty-print
+   * @throws IOException
+   *           if an I/O error occurs
+   */
+  public static void prettyPrintYaml(@NonNull File file) throws IOException {
+    ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    Object obj = mapper.readValue(file, Object.class);
+    mapper.writerWithDefaultPrettyPrinter().writeValue(file, obj);
+  }
+
+  /**
+   * Pretty-prints an XML file in place.
+   *
+   * @param file
+   *          the XML file to pretty-print
+   * @throws IOException
+   *           if an I/O error occurs
+   * @throws ParserConfigurationException
+   *           if a DocumentBuilder cannot be created
+   * @throws SAXException
+   *           if any parse errors occur
+   * @throws TransformerException
+   *           if an error occurs during transformation
+   */
+  public static void prettyPrintXml(@NonNull File file)
+      throws IOException, ParserConfigurationException, SAXException, TransformerException {
+    Document doc = DocumentBuilderFactory.newInstance()
+        .newDocumentBuilder().parse(file);
+
+    TransformerFactoryImpl transformerFactory = new TransformerFactoryImpl();
+    Transformer transformer = transformerFactory.newTransformer();
+    transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+
+    try (OutputStream out = Files.newOutputStream(file.toPath())) {
+      transformer.transform(new DOMSource(doc), new StreamResult(out));
+    }
+  }
+}

--- a/src/test/java/gov/nist/secauto/oscal/tools/cli/core/utils/PrettyPrinterTest.java
+++ b/src/test/java/gov/nist/secauto/oscal/tools/cli/core/utils/PrettyPrinterTest.java
@@ -1,0 +1,131 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package gov.nist.secauto.oscal.tools.cli.core.utils;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Tests for the {@link PrettyPrinter} utility class.
+ * <p>
+ * This feature was originally contributed by Mahesh Kumar Gaddam (ermahesh) in
+ * <a href="https://github.com/usnistgov/oscal-cli/pull/295">PR #295</a>.
+ * </p>
+ */
+class PrettyPrinterTest {
+
+  @TempDir
+  Path tempDir;
+
+  @Test
+  void testPrettyPrintJsonValidFile() throws IOException {
+    // Create a minified JSON file
+    File jsonFile = tempDir.resolve("test.json").toFile();
+    String minifiedJson = "{\"name\":\"test\",\"value\":123,\"nested\":{\"key\":\"value\"}}";
+    Files.writeString(jsonFile.toPath(), minifiedJson, StandardCharsets.UTF_8);
+
+    // Pretty print it
+    assertDoesNotThrow(() -> PrettyPrinter.prettyPrintJson(jsonFile));
+
+    // Verify the output has proper formatting
+    String content = Files.readString(jsonFile.toPath(), StandardCharsets.UTF_8);
+    assertAll(
+        () -> assertTrue(content.contains("\n"), "Pretty-printed JSON should have line breaks"),
+        () -> assertTrue(content.contains("  ") || content.contains("\t"),
+            "Pretty-printed JSON should have indentation"));
+  }
+
+  @Test
+  void testPrettyPrintJsonInvalidFile() throws IOException {
+    // Create an invalid JSON file
+    File jsonFile = tempDir.resolve("invalid.json").toFile();
+    Files.writeString(jsonFile.toPath(), "{ invalid json }", StandardCharsets.UTF_8);
+
+    // Should throw an exception
+    assertThrows(Exception.class, () -> PrettyPrinter.prettyPrintJson(jsonFile));
+  }
+
+  @Test
+  void testPrettyPrintYamlValidFile() throws IOException {
+    // Create a YAML file
+    File yamlFile = tempDir.resolve("test.yaml").toFile();
+    String yaml = "name: test\nvalue: 123\nnested:\n  key: value";
+    Files.writeString(yamlFile.toPath(), yaml, StandardCharsets.UTF_8);
+
+    // Pretty print it
+    assertDoesNotThrow(() -> PrettyPrinter.prettyPrintYaml(yamlFile));
+
+    // Verify the file still exists and has content
+    String content = Files.readString(yamlFile.toPath(), StandardCharsets.UTF_8);
+    assertTrue(!content.isBlank(), "Pretty-printed YAML should have content");
+  }
+
+  @Test
+  void testPrettyPrintXmlValidFile() throws IOException {
+    // Create a minified XML file
+    File xmlFile = tempDir.resolve("test.xml").toFile();
+    String minifiedXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root><child attr=\"value\">text</child></root>";
+    Files.writeString(xmlFile.toPath(), minifiedXml, StandardCharsets.UTF_8);
+
+    // Pretty print it
+    assertDoesNotThrow(() -> PrettyPrinter.prettyPrintXml(xmlFile));
+
+    // Verify the output has proper formatting
+    String content = Files.readString(xmlFile.toPath(), StandardCharsets.UTF_8);
+    assertAll(
+        () -> assertTrue(content.contains("\n"), "Pretty-printed XML should have line breaks"),
+        () -> assertTrue(content.contains("<root>"), "Pretty-printed XML should preserve elements"));
+  }
+
+  @Test
+  void testPrettyPrintXmlInvalidFile() throws IOException {
+    // Create an invalid XML file
+    File xmlFile = tempDir.resolve("invalid.xml").toFile();
+    Files.writeString(xmlFile.toPath(), "<invalid xml", StandardCharsets.UTF_8);
+
+    // Should throw an exception
+    assertThrows(Exception.class, () -> PrettyPrinter.prettyPrintXml(xmlFile));
+  }
+
+  @Test
+  void testPrettyPrintJsonEmptyObject() throws IOException {
+    // Create an empty JSON object file
+    File jsonFile = tempDir.resolve("empty.json").toFile();
+    Files.writeString(jsonFile.toPath(), "{}", StandardCharsets.UTF_8);
+
+    // Pretty print should work without throwing
+    assertDoesNotThrow(() -> PrettyPrinter.prettyPrintJson(jsonFile));
+
+    String content = Files.readString(jsonFile.toPath(), StandardCharsets.UTF_8);
+    assertTrue(content.contains("{"), "Pretty-printed JSON should still be valid");
+  }
+
+  @Test
+  void testPrettyPrintJsonArray() throws IOException {
+    // Create a JSON array file
+    File jsonFile = tempDir.resolve("array.json").toFile();
+    String jsonArray = "[{\"id\":1},{\"id\":2},{\"id\":3}]";
+    Files.writeString(jsonFile.toPath(), jsonArray, StandardCharsets.UTF_8);
+
+    // Pretty print it
+    assertDoesNotThrow(() -> PrettyPrinter.prettyPrintJson(jsonFile));
+
+    // Verify the output has proper formatting
+    String content = Files.readString(jsonFile.toPath(), StandardCharsets.UTF_8);
+    assertTrue(content.contains("\n"), "Pretty-printed JSON array should have line breaks");
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a `--pretty-print` command-line option for the `resolve-profile` command, enabling formatted output for XML, JSON, and YAML files.

- Added `PrettyPrinter` utility class for formatting output files in various formats
- Added `--pretty-print` CLI option to `AbstractResolveCommand`
- Added unit tests for the `PrettyPrinter` utility
- Added CLI integration tests for pretty-print functionality

## Attribution

This feature was originally contributed by **Mahesh Kumar Gaddam** ([@ermahesh](https://github.com/ermahesh)) in [usnistgov/oscal-cli#295](https://github.com/usnistgov/oscal-cli/pull/295).

## Related Issues

- Addresses [usnistgov/oscal-cli#268](https://github.com/usnistgov/oscal-cli/issues/268)

## Test plan

- [x] Unit tests for `PrettyPrinter` utility class (7 tests)
- [x] CLI integration tests for `--pretty-print` option with XML, JSON, and YAML output (3 tests)
- [x] All existing tests continue to pass