### PR TITLE
Remove deprecated --exclude-mail flag from lychee-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,7 @@ jobs:
       name: Link Checker
       uses: lycheeverse/lychee-action@82202e5e9c2f4ef1a55a3d02563e1cb6041e5332
       with:
-        args: --verbose --no-progress --accept 200,206,429 './target/staging/**/*.html'  --remap "https://github.com/metaschema-framework/oscal-cli/tree/develop/ file://${GITHUB_WORKSPACE}/" --remap "https://oscal-cli.metaschema.dev/ file://${GITHUB_WORKSPACE}/target/staging/" --exclude-mail
+        args: --verbose --no-progress --accept 200,206,429 './target/staging/**/*.html'  --remap "https://github.com/metaschema-framework/oscal-cli/tree/develop/ file://${GITHUB_WORKSPACE}/" --remap "https://oscal-cli.metaschema.dev/ file://${GITHUB_WORKSPACE}/target/staging/"
         format: markdown
         output: html-link-report.md
         debug: true


### PR DESCRIPTION
## Summary

Remove the deprecated `--exclude-mail` flag from lychee-action configuration.

- The `--exclude-mail` flag was removed in lychee-action v2.5.0
- Email addresses are now excluded from checking by default
- This change is required before upgrading lychee-action to v2.7.0 (PR #190)

## Test plan

- [x] Verify workflow runs successfully without the flag
- [ ] After merge, approve and merge PR #190 to upgrade lychee-action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modernized CI/CD workflows with updated build environments and GitHub Actions versions
  * Updated project version to 2.6.0-SNAPSHOT
  * Upgraded core, testing, and build dependencies to latest compatible versions for improved compatibility and security

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->