### PR TITLE
Update to metaschema-java 3.0.0.M1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,8 @@
 	
 	<properties>
 		<!-- metaschema dependencies -->
-		<dependency.metaschema-framework.version>2.2.0</dependency.metaschema-framework.version>
-		<dependency.liboscal-java.version>5.2.1</dependency.liboscal-java.version>
+		<dependency.metaschema-framework.version>3.0.0.M1-SNAPSHOT</dependency.metaschema-framework.version>
+		<dependency.liboscal-java.version>5.3.0-SNAPSHOT</dependency.liboscal-java.version>
 
 		<!-- site configuration -->
 		<site.url>https://oscal-cli.metaschema.dev</site.url>

--- a/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/AbstractOscalValidationCommand.java
+++ b/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/AbstractOscalValidationCommand.java
@@ -7,9 +7,11 @@ package gov.nist.secauto.oscal.tools.cli.core.commands;
 
 import gov.nist.secauto.metaschema.cli.commands.AbstractValidateContentCommand;
 import gov.nist.secauto.metaschema.cli.processor.CLIProcessor.CallingContext;
+import gov.nist.secauto.metaschema.cli.processor.ExitCode;
 import gov.nist.secauto.metaschema.cli.processor.command.CommandExecutionException;
 import gov.nist.secauto.metaschema.cli.processor.command.ICommandExecutor;
 import gov.nist.secauto.metaschema.core.model.IModule;
+import gov.nist.secauto.metaschema.core.model.MetaschemaException;
 import gov.nist.secauto.metaschema.core.model.constraint.IConstraintSet;
 import gov.nist.secauto.metaschema.core.model.validation.JsonSchemaContentValidator;
 import gov.nist.secauto.metaschema.core.model.validation.XmlSchemaContentValidator;
@@ -111,7 +113,11 @@ public abstract class AbstractOscalValidationCommand
     @Override
     protected IModule getModule(CommandLine commandLine, IBindingContext bindingContext)
         throws CommandExecutionException {
-      return bindingContext.registerModule(OscalCompleteModule.class);
+      try {
+        return bindingContext.registerModule(OscalCompleteModule.class);
+      } catch (MetaschemaException ex) {
+        throw new CommandExecutionException(ExitCode.PROCESSING_ERROR, "Failed to register OSCAL module", ex);
+      }
     }
   }
 }

--- a/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/ListAllowedValuesCommand.java
+++ b/src/main/java/gov/nist/secauto/oscal/tools/cli/core/commands/ListAllowedValuesCommand.java
@@ -22,6 +22,7 @@ import gov.nist.secauto.metaschema.core.metapath.item.node.IDefinitionNodeItem;
 import gov.nist.secauto.metaschema.core.metapath.item.node.IModuleNodeItem;
 import gov.nist.secauto.metaschema.core.metapath.item.node.INodeItemFactory;
 import gov.nist.secauto.metaschema.core.model.IModule;
+import gov.nist.secauto.metaschema.core.model.MetaschemaException;
 import gov.nist.secauto.metaschema.core.model.constraint.IAllowedValue;
 import gov.nist.secauto.metaschema.core.model.constraint.IAllowedValuesConstraint;
 import gov.nist.secauto.metaschema.core.model.constraint.IConstraintSet;
@@ -144,17 +145,21 @@ public class ListAllowedValuesCommand
         currentWorkingDirectory);
 
     IBindingContext bindingContext;
+    IBoundModule module;
     try {
       bindingContext = OscalBindingContext.builder()
           .constraintSet(constraintSets)
           .build();
+      module = bindingContext.registerModule(OscalCompleteModule.class);
+    } catch (MetaschemaException ex) {
+      throw new CommandExecutionException(ExitCode.PROCESSING_ERROR,
+          String.format("Unable to register OSCAL module. %s", ex.getLocalizedMessage()),
+          ex);
     } catch (RuntimeException ex) {
       throw new CommandExecutionException(ExitCode.RUNTIME_ERROR,
           String.format("Unable to initialize the binding context. %s", ex.getLocalizedMessage()),
           ex);
     }
-
-    IBoundModule module = bindingContext.registerModule(OscalCompleteModule.class);
 
     try {
       if (destination == null) {


### PR DESCRIPTION
## Summary

- Bump metaschema-framework version from 2.2.0 to 3.0.0.M1-SNAPSHOT
- Bump liboscal-java version from 5.2.1 to 5.3.0-SNAPSHOT
- Handle `MetaschemaException` now thrown by `IBindingContext.registerModule()`

## Changes

The `IBindingContext.registerModule()` method signature changed in metaschema-java 3.0.0 to throw a checked `MetaschemaException`. This PR updates the affected commands to properly handle this exception:

- `AbstractOscalValidationCommand`: Wrap `registerModule()` call in try-catch
- `ListAllowedValuesCommand`: Move `registerModule()` into existing try block and add specific catch clause

## Test plan

- [ ] Build compiles successfully with updated dependencies
- [ ] Existing unit tests pass
- [ ] Manual validation of CLI commands works as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated metaschema-framework and liboscal-java Maven dependencies to newer snapshot versions

* **Bug Fixes**
  * Enhanced error handling for module registration failures with more descriptive error messages and proper exit codes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->