### PR TITLE
Remove Saxon and xmlresolver dependencies

### DIFF
--- a/src/test/resources/yaml-null/example_ar_nullvar-1.yaml
+++ b/src/test/resources/yaml-null/example_ar_nullvar-1.yaml
@@ -20,15 +20,15 @@ assessment-results:
         from an assessment plan in OSCAL format and processed in GitHub Actions.
       start: 2022-12-05T18:02:05.217748+00:00
       reviewed-controls:
-        control-objective-selections:
-        - include-objectives:
-          - objective-id: ac-8_obj.a.1
-          - objective-id: ac-8_obj.a.2
-          - objective-id: ac-8_obj.a.3
-          - objective-id: ac-8_obj.a.4
         control-selections:
-        - include-controls:
-          - control-id: ac-8
+          - include-controls:
+              - control-id: ac-8
+        control-objective-selections:
+          - include-objectives:
+              - objective-id: ac-8_obj.a.1
+              - objective-id: ac-8_obj.a.2
+              - objective-id: ac-8_obj.a.3
+              - objective-id: ac-8_obj.a.4
         remarks: Control objective selections are declared separately of the include-controls
           directive, must be explicit here.
 

--- a/src/test/resources/yaml-null/example_ar_nullvar-2.yaml
+++ b/src/test/resources/yaml-null/example_ar_nullvar-2.yaml
@@ -20,15 +20,15 @@ assessment-results:
         from an assessment plan in OSCAL format and processed in GitHub Actions.
       start: 2022-12-05T18:02:05.217748+00:00
       reviewed-controls:
-        control-objective-selections:
-        - include-objectives:
-          - objective-id: ac-8_obj.a.1
-          - objective-id: ac-8_obj.a.2
-          - objective-id: ac-8_obj.a.3
-          - objective-id: ac-8_obj.a.4
         control-selections:
-        - include-controls:
-          - control-id: ac-8
+          - include-controls:
+              - control-id: ac-8
+        control-objective-selections:
+          - include-objectives:
+              - objective-id: ac-8_obj.a.1
+              - objective-id: ac-8_obj.a.2
+              - objective-id: ac-8_obj.a.3
+              - objective-id: ac-8_obj.a.4
         remarks: Control objective selections are declared separately of the include-controls
           directive, must be explicit here.
 

--- a/src/test/resources/yaml-null/example_ar_nullvar-3.yaml
+++ b/src/test/resources/yaml-null/example_ar_nullvar-3.yaml
@@ -20,15 +20,15 @@ assessment-results:
         from an assessment plan in OSCAL format and processed in GitHub Actions.
       start: 2022-12-05T18:02:05.217748+00:00
       reviewed-controls:
-        control-objective-selections:
-        - include-objectives:
-          - objective-id: ac-8_obj.a.1
-          - objective-id: ac-8_obj.a.2
-          - objective-id: ac-8_obj.a.3
-          - objective-id: ac-8_obj.a.4
         control-selections:
-        - include-controls:
-          - control-id: ac-8
+          - include-controls:
+              - control-id: ac-8
+        control-objective-selections:
+          - include-objectives:
+              - objective-id: ac-8_obj.a.1
+              - objective-id: ac-8_obj.a.2
+              - objective-id: ac-8_obj.a.3
+              - objective-id: ac-8_obj.a.4
         remarks: Control objective selections are declared separately of the include-controls
           directive, must be explicit here.
 


### PR DESCRIPTION
## Summary

- Replace Saxon `TransformerFactoryImpl` with standard Java `TransformerFactory` in `PrettyPrinter` for XML indentation
- Remove unused `xmlresolver` dependencies from pom.xml

These dependencies were removed from metaschema-java in https://github.com/metaschema-framework/metaschema-java/pull/607.

## Test plan

- [x] All 302 tests pass
- [x] Build compiles successfully
- [x] `PrettyPrinter.prettyPrintXml()` still produces properly indented output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test resource files with restructured YAML formatting. Sections reordered and nested elements reorganized across multiple test fixtures while preserving original data values and integrity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->