### PR TITLE
feat: add shell completion support

### DIFF
--- a/src/main/java/dev/metaschema/oscal/tools/cli/core/CLI.java
+++ b/src/main/java/dev/metaschema/oscal/tools/cli/core/CLI.java
@@ -7,6 +7,7 @@ package dev.metaschema.oscal.tools.cli.core;
 
 import dev.metaschema.cli.processor.CLIProcessor;
 import dev.metaschema.cli.processor.ExitStatus;
+import dev.metaschema.cli.processor.command.CommandService;
 import dev.metaschema.core.MetaschemaJavaVersion;
 import dev.metaschema.core.model.MetaschemaVersion;
 import dev.metaschema.core.util.CollectionUtil;
@@ -80,6 +81,10 @@ public final class CLI {
     processor.addCommandHandler(new ConvertCommand());
     processor.addCommandHandler(new ResolveCommand());
     processor.addCommandHandler(new ListAllowedValuesCommand());
+
+    // Register SPI-discovered commands (e.g., shell-completion)
+    CommandService.getInstance().getCommands().forEach(processor::addCommandHandler);
+
     return processor.process(args);
   }
 

--- a/src/test/java/dev/metaschema/oscal/tools/cli/core/ShellCompletionTest.java
+++ b/src/test/java/dev/metaschema/oscal/tools/cli/core/ShellCompletionTest.java
@@ -1,0 +1,126 @@
+/*
+ * SPDX-FileCopyrightText: none
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+package dev.metaschema.oscal.tools.cli.core;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.metaschema.cli.processor.ExitCode;
+import dev.metaschema.cli.processor.ExitStatus;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Tests for the shell completion command.
+ * <p>
+ * This addresses issue #85: Shell Completions.
+ * </p>
+ */
+class ShellCompletionTest {
+
+  /**
+   * Tests that the shell-completion command is available and returns help.
+   */
+  @Test
+  void testShellCompletionHelp() {
+    String[] args = { "shell-completion", "-h" };
+    ExitStatus status = CLI.runCli(args);
+
+    assertEquals(ExitCode.OK, status.getExitCode(),
+        "shell-completion -h should return OK");
+  }
+
+  /**
+   * Tests that shell-completion generates bash completion script.
+   */
+  @Test
+  void testShellCompletionBash() {
+    String[] args = { "shell-completion", "bash" };
+    ExitStatus status = CLI.runCli(args);
+
+    assertAll(
+        () -> assertEquals(ExitCode.OK, status.getExitCode(),
+            "shell-completion bash should return OK"),
+        () -> assertNull(status.getThrowable(),
+            "shell-completion bash should not throw"));
+  }
+
+  /**
+   * Tests that shell-completion generates zsh completion script.
+   */
+  @Test
+  void testShellCompletionZsh() {
+    String[] args = { "shell-completion", "zsh" };
+    ExitStatus status = CLI.runCli(args);
+
+    assertAll(
+        () -> assertEquals(ExitCode.OK, status.getExitCode(),
+            "shell-completion zsh should return OK"),
+        () -> assertNull(status.getThrowable(),
+            "shell-completion zsh should not throw"));
+  }
+
+  /**
+   * Tests that shell-completion can write to a file.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = { "bash", "zsh" })
+  void testShellCompletionToFile(String shell) throws IOException {
+    Path outputPath = Path.of("target/completion." + shell);
+    String[] args = { "shell-completion", shell, "--to", outputPath.toString() };
+
+    ExitStatus status = CLI.runCli(args);
+
+    assertAll(
+        () -> assertEquals(ExitCode.OK, status.getExitCode(),
+            "shell-completion " + shell + " --to file should return OK"),
+        () -> assertTrue(Files.exists(outputPath),
+            "Output file should exist"),
+        () -> {
+          String content = Files.readString(outputPath, StandardCharsets.UTF_8);
+          assertTrue(content.contains("oscal-cli"),
+              "Completion script should reference oscal-cli");
+        });
+
+    // Clean up
+    Files.deleteIfExists(outputPath);
+  }
+
+  /**
+   * Tests that shell-completion with invalid shell type fails gracefully.
+   */
+  @Test
+  void testShellCompletionInvalidShell() {
+    String[] args = { "shell-completion", "fish" };
+    ExitStatus status = CLI.runCli(args);
+
+    // Should fail with an invalid argument error
+    assertEquals(ExitCode.INVALID_ARGUMENTS, status.getExitCode(),
+        "shell-completion with unsupported shell should fail");
+  }
+
+  /**
+   * Tests that shell-completion without arguments shows help.
+   */
+  @Test
+  void testShellCompletionNoArgs() {
+    String[] args = { "shell-completion" };
+    ExitStatus status = CLI.runCli(args);
+
+    // Without the required shell argument, should show usage/help
+    assertEquals(ExitCode.INVALID_ARGUMENTS, status.getExitCode(),
+        "shell-completion without shell argument should fail");
+  }
+}

--- a/src/test/java/dev/metaschema/oscal/tools/cli/core/ShellCompletionTest.java
+++ b/src/test/java/dev/metaschema/oscal/tools/cli/core/ShellCompletionTest.java
@@ -81,21 +81,23 @@ class ShellCompletionTest {
     Path outputPath = Path.of("target/completion." + shell);
     String[] args = { "shell-completion", shell, "--to", outputPath.toString() };
 
-    ExitStatus status = CLI.runCli(args);
+    try {
+      ExitStatus status = CLI.runCli(args);
 
-    assertAll(
-        () -> assertEquals(ExitCode.OK, status.getExitCode(),
-            "shell-completion " + shell + " --to file should return OK"),
-        () -> assertTrue(Files.exists(outputPath),
-            "Output file should exist"),
-        () -> {
-          String content = Files.readString(outputPath, StandardCharsets.UTF_8);
-          assertTrue(content.contains("oscal-cli"),
-              "Completion script should reference oscal-cli");
-        });
-
-    // Clean up
-    Files.deleteIfExists(outputPath);
+      assertAll(
+          () -> assertEquals(ExitCode.OK, status.getExitCode(),
+              "shell-completion " + shell + " --to file should return OK"),
+          () -> assertTrue(Files.exists(outputPath),
+              "Output file should exist"),
+          () -> {
+            String content = Files.readString(outputPath, StandardCharsets.UTF_8);
+            assertTrue(content.contains("oscal-cli"),
+                "Completion script should reference oscal-cli");
+          });
+    } finally {
+      // Clean up - always runs even if assertions fail
+      Files.deleteIfExists(outputPath);
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

- Add shell completion support for bash and zsh shells
- Register SPI-discovered commands including `shell-completion` from cli-processor

## Usage

```bash
# Generate and source bash completion
oscal-cli shell-completion bash > ~/.oscal-completion.bash
source ~/.oscal-completion.bash

# Generate zsh completion
oscal-cli shell-completion zsh > ~/.zsh/completions/_oscal-cli

# Write directly to file
oscal-cli shell-completion bash --to ~/.oscal-completion.bash
```

## Changes

- Modified `CLI.java` to register SPI-discovered commands via `CommandService`
- Added `ShellCompletionTest.java` with comprehensive tests

## Dependencies

- Requires metaschema-framework/metaschema-java#632 to be merged first (fixes thread-safety issue in `CommandService`)

## Test plan

- [x] All 311 oscal-cli tests pass
- [x] Shell completion tests verify bash/zsh generation
- [x] File output with `--to` option works correctly
- [x] Invalid shell types are handled gracefully

Closes #85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now loads discovered/extendable commands at runtime, enabling plugin-style commands (including shell-completion).
  * Shell-completion command available to generate completion scripts for bash and zsh.

* **Tests**
  * Added comprehensive tests for shell-completion covering help output, script generation, file output, error handling, and argument validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->