### PR TITLE
Update metaschema-java to 3.0.0.M3 and liboscal-java to 7.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,8 @@
 	
 	<properties>
 		<!-- metaschema dependencies -->
-		<dependency.metaschema-framework.version>3.0.0-SNAPSHOT</dependency.metaschema-framework.version>
-		<dependency.liboscal-java.version>7.1.0-SNAPSHOT</dependency.liboscal-java.version>
+		<dependency.metaschema-framework.version>3.0.0.M3</dependency.metaschema-framework.version>
+		<dependency.liboscal-java.version>7.1.0</dependency.liboscal-java.version>
 
 		<!-- site configuration -->
 		<site.url>https://oscal-cli.metaschema.dev</site.url>


### PR DESCRIPTION
## Summary

- Update metaschema-java from 3.0.0-SNAPSHOT to 3.0.0.M3
- Update liboscal-java from 7.1.0-SNAPSHOT to 7.1.0

Full CI build (`mvn install -PCI -Prelease`) passes with all 309 tests succeeding and no checkstyle, PMD, SpotBugs, or coverage issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated metaschema-framework dependency to version 3.0.0.M3
  * Updated liboscal-java dependency to version 7.1.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->