### PR TITLE
fix: replace deprecated Option.Builder.build() with get()

### DIFF
--- a/src/main/java/dev/metaschema/oscal/tools/cli/core/commands/AbstractResolveCommand.java
+++ b/src/main/java/dev/metaschema/oscal/tools/cli/core/commands/AbstractResolveCommand.java
@@ -54,11 +54,11 @@ public abstract class AbstractResolveCommand
       .longOpt("relative-to")
       .desc("Generate URI references relative to this resource")
       .hasArg()
-      .build();
+      .get();
   private static final Option PRETTY_PRINT_OPTION = Option.builder()
       .longOpt("pretty-print")
       .desc("Enable pretty-printing of the output for better readability")
-      .build();
+      .get();
 
   @NonNull
   private static final List<Option> OPTIONS = ObjectUtils.notNull(

--- a/src/main/java/dev/metaschema/oscal/tools/cli/core/commands/ListAllowedValuesCommand.java
+++ b/src/main/java/dev/metaschema/oscal/tools/cli/core/commands/ListAllowedValuesCommand.java
@@ -80,7 +80,7 @@ public class ListAllowedValuesCommand
           .hasArgs()
           .argName("URL")
           .desc("additional constraint definitions")
-          .build());
+          .get());
 
   @Override
   public String getName() {


### PR DESCRIPTION
## Summary

- Replace deprecated `Option.Builder.build()` calls with `get()` in `AbstractResolveCommand` and `ListAllowedValuesCommand`. The `build()` method was deprecated in Apache Commons CLI 1.9 in favor of `get()` (the `Builder` now implements `Supplier<Option>`).

## Test plan

- [x] Build succeeds with no deprecation warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal option initialization methods in command processing modules to standardize builder chain retrieval patterns. Enhanced code consistency and maintainability by implementing uniform approaches across multiple command classes. These architectural improvements strengthen internal code quality without affecting the public API, user-facing functionality, or command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->