### PR TITLE
deprecate: mark ListAllowedValuesCommand as deprecated

### DIFF
--- a/src/main/java/dev/metaschema/oscal/tools/cli/core/commands/ListAllowedValuesCommand.java
+++ b/src/main/java/dev/metaschema/oscal/tools/cli/core/commands/ListAllowedValuesCommand.java
@@ -63,7 +63,12 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 /**
  * A CLI command that provides a listing of allowed values constraints by
  * targeted node.
+ *
+ * @deprecated Use the {@code list-allowed-values} command in
+ *             {@code metaschema-cli} instead. This command will be removed in a
+ *             future release.
  */
+@Deprecated(since = "3.0.0")
 @SuppressWarnings("PMD.CouplingBetweenObjects")
 public class ListAllowedValuesCommand
     extends AbstractTerminalCommand {
@@ -89,7 +94,8 @@ public class ListAllowedValuesCommand
 
   @Override
   public String getDescription() {
-    return "List allowed values constraints for the provided Metaschema module";
+    return "[Deprecated: use metaschema-cli list-allowed-values] "
+        + "List allowed values constraints for the provided Metaschema module";
   }
 
   @SuppressWarnings("null")


### PR DESCRIPTION
## Summary

- Adds `@Deprecated(since = "3.0.0")` annotation to `ListAllowedValuesCommand`
- Adds `@deprecated` Javadoc tag directing users to `metaschema-cli list-allowed-values`
- Updates command description to include deprecation notice

## Context

The `list-allowed-values` command has been migrated to metaschema-cli, making it available without requiring OSCAL-specific dependencies. The oscal-cli version is deprecated but retained for backward compatibility.

The import will be updated from `dev.metaschema.oscal.lib.model.util` to `dev.metaschema.core.metapath.item.node` in a follow-up once the metaschema-java dependency version is bumped.

**Depends on:** metaschema-framework/metaschema-java#666

## Test plan

- [x] Full CI build passes (`mvn clean install -PCI -Prelease`)
- [x] Deprecation annotation renders correctly in Javadoc
- [x] Command description shows deprecation notice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deprecated the "list-allowed-values" command as of version 3.0.0. Users should migrate to using the metaschema-cli tool for this functionality going forward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->