### PR TITLE
ci: pin Trivy version to v0.69.3 to fix failing install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,6 +204,11 @@ jobs:
       if: ${{ !inputs.skip_code_scans }}
       uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
       with:
+        # Pin a Trivy version whose release artifacts are still published.
+        # Older versions (including the action's default v0.65.0) had their
+        # release assets removed, breaking install.sh. See
+        # https://github.com/aquasecurity/trivy/discussions/10265
+        version: 'v0.69.3'
         scan-type: 'fs'
         scan-ref: '.'
         scanners: 'vuln,secret,misconfig'


### PR DESCRIPTION
## Summary

The Code CI job has been failing on dependabot PRs since late March because the Trivy install step exits with code 1 during setup. The aquasecurity/trivy-action defaults to installing Trivy `v0.65.0`, but release artifacts for older Trivy versions were removed upstream, so `contrib/install.sh` can no longer fetch them.

This pins `version: v0.69.3` on the trivy-action invocation so install.sh targets a release whose assets are still published.

## Changes

- `.github/workflows/build.yml` — add `version: 'v0.69.3'` to the Trivy step, with a comment linking to the upstream discussion.

## References

- https://github.com/aquasecurity/trivy/discussions/10265 — upstream announcement of the removed artifacts
- aquasecurity/setup-trivy#30 — tracking issue for the install failure, with confirmed working mitigation

## Test Plan

- [ ] CI `Code` job passes on this PR (previously failing on dependabot PRs #251, #252, #255)
- [ ] Trivy scan completes and SARIF output is produced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security scanning by explicitly specifying a pinned version of the security tool in the build process, ensuring consistency and reproducibility of security checks across releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->