### PR TITLE
fix: preserve sub-manifest digests during container cleanup (#254)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     - release/**
     - develop
     - feature/**
+    tags:
+    - 'v*'
   pull_request:
     types: [opened, synchronize, reopened]
     branches:

--- a/.github/workflows/container-cleanup.yml
+++ b/.github/workflows/container-cleanup.yml
@@ -10,6 +10,10 @@ on:
         required: false
         default: false
         type: boolean
+env:
+  REGISTRY: ghcr.io
+  OWNER: metaschema-framework
+  IMAGE_NAME: oscal-cli
 jobs:
   cleanup-images:
     name: Prune Old Container Images
@@ -17,14 +21,56 @@ jobs:
     permissions:
       packages: write
     steps:
+    # GHCR's packages API reports per-platform sub-manifests and attestation
+    # manifests of a multi-platform image as standalone untagged versions. The
+    # retention policy action, per the workaround documented at
+    # https://github.com/snok/container-retention-policy#safely-handling-multi-platform-multi-arch-packages,
+    # cannot infer which sub-manifests are referenced by which tagged index.
+    # Without this pre-step, cleanup prunes the sub-manifests of `:latest` and
+    # `v*` tags while leaving the index intact, leaving pulls broken with
+    # "manifest ... not found" (oscal-cli#254). Collect the referenced digests
+    # here and pass them through `skip-shas`.
+    - name: Collect sub-manifest digests of protected tags
+      id: protected
+      shell: bash
+      run: |
+        set -euo pipefail
+        token=$(curl -fsSL "https://${REGISTRY}/token?service=${REGISTRY}&scope=repository:${OWNER}/${IMAGE_NAME}:pull" | jq -r '.token')
+        accept='application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json'
+
+        tags_file=$(mktemp)
+        printf 'latest\n' > "$tags_file"
+        gh api --paginate "orgs/${OWNER}/packages/container/${IMAGE_NAME}/versions" \
+          --jq '.[].metadata.container.tags[]?' \
+          | grep -E '^v[0-9]' \
+          >> "$tags_file" || true
+        sort -u "$tags_file" -o "$tags_file"
+
+        digests_file=$(mktemp)
+        while IFS= read -r tag; do
+          [ -z "$tag" ] && continue
+          manifest=$(curl -fsSL -H "Authorization: Bearer $token" -H "Accept: $accept" \
+            "https://${REGISTRY}/v2/${OWNER}/${IMAGE_NAME}/manifests/$tag" 2>/dev/null || true)
+          [ -z "$manifest" ] && continue
+          echo "$manifest" | jq -r '.manifests[]?.digest // empty' >> "$digests_file"
+        done < "$tags_file"
+
+        sort -u "$digests_file" -o "$digests_file"
+        count=$(wc -l < "$digests_file" | tr -d ' ')
+        skip_shas=$(paste -sd ',' "$digests_file")
+        echo "Protecting $count sub-manifest digest(s) across $(wc -l < $tags_file | tr -d ' ') tag(s)"
+        echo "skip-shas=$skip_shas" >> "$GITHUB_OUTPUT"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Delete old container images
       uses: snok/container-retention-policy@3b0972b2276b171b212f8c4efbca59ebba26eceb
       with:
-        account: metaschema-framework
-        image-names: oscal-cli
+        account: ${{ env.OWNER }}
+        image-names: ${{ env.IMAGE_NAME }}
         cut-off: 7d
         keep-n-most-recent: 5
         image-tags: "!latest !v*"
         tag-selection: both
+        skip-shas: ${{ steps.protected.outputs.skip-shas }}
         dry-run: ${{ inputs.dry-run || false }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/container-cleanup.yml
+++ b/.github/workflows/container-cleanup.yml
@@ -58,7 +58,7 @@ jobs:
         sort -u "$digests_file" -o "$digests_file"
         count=$(wc -l < "$digests_file" | tr -d ' ')
         skip_shas=$(paste -sd ',' "$digests_file")
-        echo "Protecting $count sub-manifest digest(s) across $(wc -l < $tags_file | tr -d ' ') tag(s)"
+        echo "Protecting $count sub-manifest digest(s) across $(wc -l < "$tags_file" | tr -d ' ') tag(s)"
         echo "skip-shas=$skip_shas" >> "$GITHUB_OUTPUT"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -60,7 +60,7 @@ jobs:
           type=ref,event=tag
           type=ref,event=pr
         flavor: |
-          latest=${{ github.ref == 'refs/heads/main' }}
+          latest=auto
         annotations: |
           maintainers="Metaschema Community Admin <admin@metaschema.dev>"
           org.opencontainers.image.authors="Metaschema Community Admin <admin@metaschema.dev>"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -57,8 +57,10 @@ jobs:
         tags: |
           type=sha,prefix=,suffix=,format=long
           type=ref,event=branch
-          type=ref,event=tag
           type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
         flavor: |
           latest=auto
         annotations: |


### PR DESCRIPTION
Closes #254.

## Summary

`docker/finch pull ghcr.io/metaschema-framework/oscal-cli:latest` fails with `FATA[0000] failed to copy: ... content at .../manifests/sha256:... not found`. Verified against the current registry state: the `:latest` index (digest `sha256:f304f679…`) is intact, but all four of its referenced sub-manifests (amd64 image, arm64 image, and the two attestation manifests) return 404.

## Root cause

`.github/workflows/container-cleanup.yml` runs daily with `snok/container-retention-policy`, filter `image-tags: "!latest !v*"`. That filter keeps images **tagged** `latest` or `v*`, but GHCR's packages API reports each multi-platform push as:

- one tagged OCI image index (e.g. `:latest`), and
- several **untagged** package versions — the per-platform sub-manifests and the attestation manifests the index references

The action cannot infer which untagged versions are "children" of a protected index — this limitation is called out explicitly in the [action's README](https://github.com/snok/container-retention-policy#safely-handling-multi-platform-multi-arch-packages). The untagged children match the `!latest !v*` deletion filter, age past the 7-day cut-off, and are pruned, leaving the tagged index dangling.

As a secondary issue, `:latest` was being set on every push to `main` (`flavor: latest=${{ github.ref == 'refs/heads/main' }}`). That means `:latest` could jump to a fresh image at any time, and the *previous* `:latest`'s sub-manifests — once the tag moved off them — were immediately in the delete pool.

## Fix

Two changes, applied together:

1. **`container-cleanup.yml`** — add a pre-step that enumerates every version currently tagged `latest` or `v*` via the GHCR packages API, fetches each index manifest from the OCI registry, extracts every referenced sub-manifest digest, and passes the deduped list through `skip-shas`. This is the mitigation the action's own docs recommend.

2. **`container.yml`** + **`build.yml`** — switch the `latest` tag from "applied on every main push" to `flavor: latest=auto`, and add `tags: v*` to the build workflow's push triggers. `latest=auto` publishes `:latest` on tagged-release pushes only, so the tag tracks an immutable release instead of the tip of main. This also aligns `:latest` with the existing `!latest !v*` protection — the tag and the version it points to are both retained.

## Notes

- The *currently* broken `:latest` in GHCR will not be repaired by this PR; the dangling sub-manifests are already gone. It will be replaced on the next tagged release build, which now publishes `:latest` automatically.
- Tested the enumeration pre-step locally: against the current registry it correctly identifies the four sub-manifest digests that `:latest` index references (the same four currently returning 404). Once a fresh `:latest` is published, those digests will be live and this skip-list will prevent the cleanup from repeating the break.

## Test plan

- [ ] CI builds pass on this PR
- [ ] After merge, trigger `Container Image Cleanup` with `dry-run: true` via `workflow_dispatch` and confirm the log line reports a non-zero digest count and that no protected digests appear in the deletion plan
- [ ] Next tagged release (post-merge) publishes a fresh `:latest`; pulling `ghcr.io/metaschema-framework/oscal-cli:latest` succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs for pushes of version-style tags (e.g., v*), so tagged releases trigger builds and tests.
  * Container cleanup preserves images referenced by protected tags by detecting and skipping their underlying manifest digests during pruning.
  * Docker image metadata tagging now uses semver-derived tag patterns and lets the tagging tool automatically decide when to apply the "latest" tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->