### PR TITLE
build: bump metaschema-framework to 3.0.0-SNAPSHOT and liboscal-java to 7.2.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,8 @@
 	
 	<properties>
 		<!-- metaschema dependencies -->
-		<dependency.metaschema-framework.version>3.0.0.M3</dependency.metaschema-framework.version>
-		<dependency.liboscal-java.version>7.1.0</dependency.liboscal-java.version>
+		<dependency.metaschema-framework.version>3.0.0-SNAPSHOT</dependency.metaschema-framework.version>
+		<dependency.liboscal-java.version>7.2.0-SNAPSHOT</dependency.liboscal-java.version>
 
 		<!-- site configuration -->
 		<site.url>https://oscal-cli.metaschema.dev</site.url>
@@ -156,6 +156,14 @@
 
 	<dependencyManagement>
 		<dependencies>
+			<dependency>
+				<groupId>dev.metaschema.java</groupId>
+				<artifactId>metaschema-framework</artifactId>
+				<version>${dependency.metaschema-framework.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-bom</artifactId>

--- a/src/main/java/dev/metaschema/oscal/tools/cli/core/commands/ListAllowedValuesCommand.java
+++ b/src/main/java/dev/metaschema/oscal/tools/cli/core/commands/ListAllowedValuesCommand.java
@@ -42,6 +42,8 @@ import dev.metaschema.cli.processor.command.ExtraArgument;
 import dev.metaschema.cli.processor.command.ICommandExecutor;
 import dev.metaschema.core.metapath.DynamicContext;
 import dev.metaschema.core.metapath.StaticContext;
+import dev.metaschema.core.metapath.item.node.AllowedValueCollectingNodeItemVisitor;
+import dev.metaschema.core.metapath.item.node.AllowedValueCollectingNodeItemVisitor.AllowedValuesRecord;
 import dev.metaschema.core.metapath.item.node.IDefinitionNodeItem;
 import dev.metaschema.core.metapath.item.node.IModuleNodeItem;
 import dev.metaschema.core.metapath.item.node.INodeItemFactory;
@@ -55,8 +57,6 @@ import dev.metaschema.databind.IBindingContext;
 import dev.metaschema.databind.model.IBoundModule;
 import dev.metaschema.oscal.lib.OscalBindingContext;
 import dev.metaschema.oscal.lib.model.OscalCompleteModule;
-import dev.metaschema.oscal.lib.model.util.AllowedValueCollectingNodeItemVisitor;
-import dev.metaschema.oscal.lib.model.util.AllowedValueCollectingNodeItemVisitor.AllowedValuesRecord;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 


### PR DESCRIPTION
## Summary

Picks up [liboscal-java#280](https://github.com/metaschema-framework/liboscal-java/pull/280), which moved \`AllowedValueCollectingNodeItemVisitor\` (and its \`AllowedValuesRecord\` / \`NodeItemRecord\` inner classes) out of \`dev.metaschema.oscal.lib.model.util\` and into \`metaschema-java\` core at \`dev.metaschema.core.metapath.item.node\`. Attempting to build against liboscal-java 7.2.0-SNAPSHOT on current \`develop\` fails to compile \`ListAllowedValuesCommand\` because the old package is gone.

## Changes

- \`pom.xml\` — bump \`dependency.metaschema-framework.version\` to \`3.0.0-SNAPSHOT\` and \`dependency.liboscal-java.version\` to \`7.2.0-SNAPSHOT\`.
- \`pom.xml\` — import the \`metaschema-framework\` BOM in \`<dependencyManagement>\`. Without this, liboscal-java 7.2.0-SNAPSHOT's own POM still pins \`metaschema-core\` to \`3.0.0.M3\` transitively, which pre-dates the class move and puts the build back at square one.
- \`ListAllowedValuesCommand.java\` — update the two imports for \`AllowedValueCollectingNodeItemVisitor\` and \`AllowedValuesRecord\` to the new \`dev.metaschema.core.metapath.item.node\` location. No behavioural change — the class API (methods on the outer visitor plus \`getTarget\`, \`getLocation\`, \`getAllowedValues\` on the record) is identical.

## Test plan

- [x] \`mvn compile\` — passes
- [x] \`mvn test\` — 309 tests, 0 failures, 0 errors
- [ ] CI (including CodeQL + Trivy) passes on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated managed dependency versions for metaschema-framework (3.0.0-SNAPSHOT) and liboscal-java (7.2.0-SNAPSHOT).
  * Enhanced build configuration by importing metaschema-framework BOM for improved transitive dependency management.

* **Refactor**
  * Updated internal dependency references for allowed values processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->