### PR TITLE
build: bump metaschema-framework to 3.0.0.M4 and liboscal-java to 7.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,8 @@
 	
 	<properties>
 		<!-- metaschema dependencies -->
-		<dependency.metaschema-framework.version>3.0.0-SNAPSHOT</dependency.metaschema-framework.version>
-		<dependency.liboscal-java.version>7.2.0-SNAPSHOT</dependency.liboscal-java.version>
+		<dependency.metaschema-framework.version>3.0.0.M4</dependency.metaschema-framework.version>
+		<dependency.liboscal-java.version>7.2.0</dependency.liboscal-java.version>
 
 		<!-- site configuration -->
 		<site.url>https://oscal-cli.metaschema.dev</site.url>


### PR DESCRIPTION
## Summary

- Bump `metaschema-framework` from `3.0.0-SNAPSHOT` to `3.0.0.M4` (released to Maven Central)
- Bump `liboscal-java` from `7.2.0-SNAPSHOT` to `7.2.0`

## Notes

`liboscal-java 7.2.0` is not yet published to Maven Central at the time this PR is opened. CI will fail to resolve the dependency until that release lands. Hold merge until the release is available.

## Test plan

- [ ] CI green after `liboscal-java 7.2.0` is published
- [ ] `mvn install -PCI -Prelease` succeeds locally
- [ ] `mvn test` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated metaschema-framework dependency to stable version 3.0.0.M4
  * Updated liboscal-java dependency to stable version 7.2.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/metaschema-framework/oscal-cli/pull/273)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->