### PR TITLE
ci: fix scheduled-build permissions and expose workflow_dispatch inputs

### DIFF
--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -4,15 +4,34 @@ on:
     # Nightly build at 4:00 AM UTC (after liboscal-java)
     - cron: '0 4 * * *'
   workflow_dispatch:
-permissions:
-  actions: read
-  contents: write
-  security-events: write
+    inputs:
+      ref:
+        description: 'Git ref to checkout (branch, tag, or SHA)'
+        required: false
+        default: 'develop'
+        type: string
+      skip_code_scans:
+        description: 'Skip CodeQL and Trivy security scans'
+        required: false
+        default: true
+        type: boolean
+      skip_linkcheck:
+        description: 'Skip website link checker'
+        required: false
+        default: true
+        type: boolean
 jobs:
   nightly:
+    permissions:
+      actions: read
+      contents: write
+      security-events: write
+      packages: write
+      attestations: write
+      id-token: write
     uses: ./.github/workflows/build.yml
     with:
-      ref: develop
-      skip_code_scans: true
-      skip_linkcheck: true
+      ref: ${{ inputs.ref || 'develop' }}
+      skip_code_scans: ${{ github.event_name == 'schedule' || inputs.skip_code_scans }}
+      skip_linkcheck: ${{ github.event_name == 'schedule' || inputs.skip_linkcheck }}
     secrets: inherit


### PR DESCRIPTION
## Summary

- Declare the union of required permissions (`actions: read`, `contents: write`, `security-events: write`, `packages: write`, `attestations: write`, `id-token: write`) on the `nightly` caller job so the reusable `build.yml` can run. Without this, GitHub rejected the workflow because the called jobs request more permissions than the caller granted.
- Expose `ref`, `skip_code_scans`, and `skip_linkcheck` as `workflow_dispatch` inputs so manual runs can override them. Scheduled runs keep the existing hardcoded behavior (`develop`, both skips true) via a `github.event_name == 'schedule' || inputs.X` guard that avoids the falsy-default trap of `|| true`.

Targets `main` because scheduled workflows only fire from the default branch. Mirrors the equivalent fix in `metaschema-framework/metaschema-java#722`.

## Test plan

- [ ] After merge, trigger the workflow via `workflow_dispatch` and confirm it starts cleanly
- [ ] Confirm the next scheduled (4:00 AM UTC) run executes without permission errors
- [ ] Verify `workflow_dispatch` inputs are visible and overridable from the Actions UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduled build workflow can be manually triggered with configurable inputs (branch/ref, toggle code scans, toggle link checks).
  * Manual triggers respect provided inputs while scheduled runs keep defaults.

* **Chores**
  * Build pipeline permissions moved to job-level and expanded to include additional write permissions for package/attestation/token-related actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/metaschema-framework/oscal-cli/pull/274)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->